### PR TITLE
added a new tag 'Boost Productivity' and a package 'projectman'

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,5 @@ List of packages needed for management and operations.
 #### Code Quality Analysis
 * [`Plato`](https://github.com/es-analysis/plato) - JavaScript source code visualization, static analysis, and complexity tool.
 
+#### Boost Productivity
+* [`ProjectMan`](https://github.com/saurabhdaware/projectman) - A Project Manager to add projects to favorites and open them from your command-line.


### PR DESCRIPTION
Hi, I made this package a month back called `projectman`. It lets you add projects to favorites and open them from command-line tool with command `pm open` so you don't have to `cd /till/the/project/path` to open projects. Along with this it also provides ability to set different Editors/IDE.

You can check it out https://github.com/saurabhdaware/projectman and merge this if you find it useful. 

Do let me know if you want me to put it inside other tag or change the name of the tag